### PR TITLE
feat: Add GitHub Actions status monitoring controller

### DIFF
--- a/src/main/java/com/scheduler/controller/GitHubActionsController.java
+++ b/src/main/java/com/scheduler/controller/GitHubActionsController.java
@@ -1,0 +1,94 @@
+package com.scheduler.controller;
+
+import com.scheduler.model.WorkflowRun;
+import com.scheduler.model.WorkflowRunsResponse;
+import com.scheduler.service.GitHubActionsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+/**
+ * GitHub Actions状态监控控制器
+ * 提供实时获取GitHub Actions工作流运行状态的API
+ */
+@RestController
+@RequestMapping("/api/v1/github-actions")
+@RequiredArgsConstructor
+public class GitHubActionsController {
+
+    private final GitHubActionsService gitHubActionsService;
+
+    /**
+     * 获取仓库的工作流运行列表
+     * GET /api/v1/github-actions/{owner}/{repo}/runs
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param perPage 每页数量（可选，默认30）
+     * @param page 页码（可选，默认1）
+     * @return 工作流运行列表
+     */
+    @GetMapping("/{owner}/{repo}/runs")
+    public Mono<WorkflowRunsResponse> getWorkflowRuns(
+            @PathVariable String owner,
+            @PathVariable String repo,
+            @RequestParam(required = false, defaultValue = "30") Integer perPage,
+            @RequestParam(required = false, defaultValue = "1") Integer page) {
+        return gitHubActionsService.getWorkflowRuns(owner, repo, perPage, page);
+    }
+
+    /**
+     * 获取单个工作流运行的详细信息
+     * GET /api/v1/github-actions/{owner}/{repo}/runs/{runId}
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param runId 运行ID
+     * @return 工作流运行详情
+     */
+    @GetMapping("/{owner}/{repo}/runs/{runId}")
+    public Mono<WorkflowRun> getWorkflowRun(
+            @PathVariable String owner,
+            @PathVariable String repo,
+            @PathVariable Long runId) {
+        return gitHubActionsService.getWorkflowRun(owner, repo, runId);
+    }
+
+    /**
+     * 获取特定分支的工作流运行列表
+     * GET /api/v1/github-actions/{owner}/{repo}/runs/branch/{branch}
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param branch 分支名称
+     * @param perPage 每页数量（可选，默认30）
+     * @return 工作流运行列表
+     */
+    @GetMapping("/{owner}/{repo}/runs/branch/{branch}")
+    public Mono<WorkflowRunsResponse> getWorkflowRunsByBranch(
+            @PathVariable String owner,
+            @PathVariable String repo,
+            @PathVariable String branch,
+            @RequestParam(required = false, defaultValue = "30") Integer perPage) {
+        return gitHubActionsService.getWorkflowRunsByBranch(owner, repo, branch, perPage);
+    }
+
+    /**
+     * 获取特定状态的工作流运行列表
+     * GET /api/v1/github-actions/{owner}/{repo}/runs/status/{status}
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param status 状态 (completed, in_progress, queued)
+     * @param perPage 每页数量（可选，默认30）
+     * @return 工作流运行列表
+     */
+    @GetMapping("/{owner}/{repo}/runs/status/{status}")
+    public Mono<WorkflowRunsResponse> getWorkflowRunsByStatus(
+            @PathVariable String owner,
+            @PathVariable String repo,
+            @PathVariable String status,
+            @RequestParam(required = false, defaultValue = "30") Integer perPage) {
+        return gitHubActionsService.getWorkflowRunsByStatus(owner, repo, status, perPage);
+    }
+}

--- a/src/main/java/com/scheduler/model/WorkflowRun.java
+++ b/src/main/java/com/scheduler/model/WorkflowRun.java
@@ -1,0 +1,81 @@
+package com.scheduler.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * GitHub Actions工作流运行信息
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkflowRun {
+
+    /**
+     * 运行ID
+     */
+    private Long id;
+
+    /**
+     * 运行编号
+     */
+    private Integer runNumber;
+
+    /**
+     * 工作流名称
+     */
+    private String name;
+
+    /**
+     * 状态
+     */
+    private String status;
+
+    /**
+     * 结论
+     */
+    private String conclusion;
+
+    /**
+     * 分支
+     */
+    private String headBranch;
+
+    /**
+     * 提交SHA
+     */
+    private String headSha;
+
+    /**
+     * 创建时间
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * 更新时间
+     */
+    private LocalDateTime updatedAt;
+
+    /**
+     * 运行开始时间
+     */
+    private LocalDateTime runStartedAt;
+
+    /**
+     * HTML URL
+     */
+    private String htmlUrl;
+
+    /**
+     * 触发事件
+     */
+    private String event;
+
+    /**
+     * 触发者
+     */
+    private String actor;
+}

--- a/src/main/java/com/scheduler/model/WorkflowRunsResponse.java
+++ b/src/main/java/com/scheduler/model/WorkflowRunsResponse.java
@@ -1,0 +1,26 @@
+package com.scheduler.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * GitHub Actions工作流运行列表响应
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkflowRunsResponse {
+
+    /**
+     * 总数量
+     */
+    private Integer totalCount;
+
+    /**
+     * 工作流运行列表
+     */
+    private List<WorkflowRun> workflowRuns;
+}

--- a/src/main/java/com/scheduler/service/GitHubActionsService.java
+++ b/src/main/java/com/scheduler/service/GitHubActionsService.java
@@ -1,0 +1,208 @@
+package com.scheduler.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scheduler.model.WorkflowRun;
+import com.scheduler.model.WorkflowRunsResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * GitHub Actions API服务
+ * 用于实时获取GitHub Actions工作流运行状态
+ */
+@Service
+@Slf4j
+public class GitHubActionsService {
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+
+    public GitHubActionsService(
+            @Value("${github.api.token:}") String githubToken,
+            ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+
+        WebClient.Builder builder = WebClient.builder()
+                .baseUrl("https://api.github.com")
+                .defaultHeader("Accept", "application/vnd.github+json")
+                .defaultHeader("X-GitHub-Api-Version", "2022-11-28");
+
+        // 如果配置了token，添加认证头
+        if (githubToken != null && !githubToken.isEmpty()) {
+            builder.defaultHeader("Authorization", "Bearer " + githubToken);
+        }
+
+        this.webClient = builder.build();
+    }
+
+    /**
+     * 获取仓库的工作流运行列表
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param perPage 每页数量
+     * @param page 页码
+     * @return 工作流运行响应
+     */
+    public Mono<WorkflowRunsResponse> getWorkflowRuns(String owner, String repo, Integer perPage, Integer page) {
+        String url = String.format("/repos/%s/%s/actions/runs", owner, repo);
+
+        return webClient.get()
+                .uri(uriBuilder -> {
+                    uriBuilder.path(url);
+                    if (perPage != null) {
+                        uriBuilder.queryParam("per_page", perPage);
+                    }
+                    if (page != null) {
+                        uriBuilder.queryParam("page", page);
+                    }
+                    return uriBuilder.build();
+                })
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(this::parseWorkflowRunsResponse)
+                .doOnError(error -> log.error("Error fetching workflow runs: {}", error.getMessage()));
+    }
+
+    /**
+     * 获取单个工作流运行的详细信息
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param runId 运行ID
+     * @return 工作流运行详情
+     */
+    public Mono<WorkflowRun> getWorkflowRun(String owner, String repo, Long runId) {
+        String url = String.format("/repos/%s/%s/actions/runs/%d", owner, repo, runId);
+
+        return webClient.get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(this::parseWorkflowRun)
+                .doOnError(error -> log.error("Error fetching workflow run {}: {}", runId, error.getMessage()));
+    }
+
+    /**
+     * 获取特定分支的工作流运行列表
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param branch 分支名称
+     * @param perPage 每页数量
+     * @return 工作流运行响应
+     */
+    public Mono<WorkflowRunsResponse> getWorkflowRunsByBranch(String owner, String repo, String branch, Integer perPage) {
+        String url = String.format("/repos/%s/%s/actions/runs", owner, repo);
+
+        return webClient.get()
+                .uri(uriBuilder -> {
+                    uriBuilder.path(url)
+                            .queryParam("branch", branch);
+                    if (perPage != null) {
+                        uriBuilder.queryParam("per_page", perPage);
+                    }
+                    return uriBuilder.build();
+                })
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(this::parseWorkflowRunsResponse)
+                .doOnError(error -> log.error("Error fetching workflow runs for branch {}: {}", branch, error.getMessage()));
+    }
+
+    /**
+     * 获取特定状态的工作流运行列表
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param status 状态 (completed, in_progress, queued)
+     * @param perPage 每页数量
+     * @return 工作流运行响应
+     */
+    public Mono<WorkflowRunsResponse> getWorkflowRunsByStatus(String owner, String repo, String status, Integer perPage) {
+        String url = String.format("/repos/%s/%s/actions/runs", owner, repo);
+
+        return webClient.get()
+                .uri(uriBuilder -> {
+                    uriBuilder.path(url)
+                            .queryParam("status", status);
+                    if (perPage != null) {
+                        uriBuilder.queryParam("per_page", perPage);
+                    }
+                    return uriBuilder.build();
+                })
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .map(this::parseWorkflowRunsResponse)
+                .doOnError(error -> log.error("Error fetching workflow runs with status {}: {}", status, error.getMessage()));
+    }
+
+    /**
+     * 解析工作流运行列表响应
+     */
+    private WorkflowRunsResponse parseWorkflowRunsResponse(JsonNode jsonNode) {
+        WorkflowRunsResponse response = new WorkflowRunsResponse();
+        response.setTotalCount(jsonNode.get("total_count").asInt());
+
+        List<WorkflowRun> workflowRuns = new ArrayList<>();
+        JsonNode runsNode = jsonNode.get("workflow_runs");
+
+        if (runsNode != null && runsNode.isArray()) {
+            for (JsonNode runNode : runsNode) {
+                workflowRuns.add(parseWorkflowRun(runNode));
+            }
+        }
+
+        response.setWorkflowRuns(workflowRuns);
+        return response;
+    }
+
+    /**
+     * 解析单个工作流运行
+     */
+    private WorkflowRun parseWorkflowRun(JsonNode node) {
+        WorkflowRun run = new WorkflowRun();
+        run.setId(node.get("id").asLong());
+        run.setRunNumber(node.get("run_number").asInt());
+        run.setName(node.get("name").asText());
+        run.setStatus(node.get("status").asText());
+
+        JsonNode conclusionNode = node.get("conclusion");
+        if (conclusionNode != null && !conclusionNode.isNull()) {
+            run.setConclusion(conclusionNode.asText());
+        }
+
+        run.setHeadBranch(node.get("head_branch").asText());
+        run.setHeadSha(node.get("head_sha").asText());
+        run.setHtmlUrl(node.get("html_url").asText());
+        run.setEvent(node.get("event").asText());
+
+        JsonNode actorNode = node.get("actor");
+        if (actorNode != null && actorNode.has("login")) {
+            run.setActor(actorNode.get("login").asText());
+        }
+
+        // 解析时间
+        if (node.has("created_at") && !node.get("created_at").isNull()) {
+            run.setCreatedAt(LocalDateTime.parse(node.get("created_at").asText(), ISO_FORMATTER));
+        }
+        if (node.has("updated_at") && !node.get("updated_at").isNull()) {
+            run.setUpdatedAt(LocalDateTime.parse(node.get("updated_at").asText(), ISO_FORMATTER));
+        }
+        if (node.has("run_started_at") && !node.get("run_started_at").isNull()) {
+            run.setRunStartedAt(LocalDateTime.parse(node.get("run_started_at").asText(), ISO_FORMATTER));
+        }
+
+        return run;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,10 @@ scheduler:
     connection-timeout: 10000
     # Runner执行超时时间（毫秒）
     execution-timeout: 30000
+
+# GitHub API配置
+github:
+  api:
+    # GitHub Personal Access Token (可选，未设置时使用匿名访问，有速率限制)
+    # 设置方式: export GITHUB_API_TOKEN=your_token 或在此配置
+    token: ${GITHUB_API_TOKEN:}

--- a/src/test/java/com/scheduler/controller/GitHubActionsControllerTest.java
+++ b/src/test/java/com/scheduler/controller/GitHubActionsControllerTest.java
@@ -1,0 +1,142 @@
+package com.scheduler.controller;
+
+import com.scheduler.model.WorkflowRun;
+import com.scheduler.model.WorkflowRunsResponse;
+import com.scheduler.service.GitHubActionsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+class GitHubActionsControllerTest {
+
+    private WebTestClient webTestClient;
+
+    @Mock
+    private GitHubActionsService gitHubActionsService;
+
+    private GitHubActionsController controller;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        controller = new GitHubActionsController(gitHubActionsService);
+        webTestClient = WebTestClient.bindToController(controller).build();
+    }
+
+    @Test
+    void testGetWorkflowRuns() {
+        WorkflowRunsResponse response = new WorkflowRunsResponse();
+        response.setTotalCount(1);
+
+        WorkflowRun run = new WorkflowRun();
+        run.setId(12345L);
+        run.setRunNumber(1);
+        run.setName("Test Workflow");
+        run.setStatus("completed");
+        run.setConclusion("success");
+        run.setHeadBranch("main");
+        run.setHeadSha("abc123");
+        run.setCreatedAt(LocalDateTime.now());
+        run.setHtmlUrl("https://github.com/test/repo/actions/runs/12345");
+        run.setEvent("push");
+        run.setActor("testuser");
+
+        response.setWorkflowRuns(Arrays.asList(run));
+
+        when(gitHubActionsService.getWorkflowRuns(anyString(), anyString(), anyInt(), anyInt()))
+                .thenReturn(Mono.just(response));
+
+        webTestClient.get()
+                .uri("/api/v1/github-actions/testowner/testrepo/runs?perPage=30&page=1")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.totalCount").isEqualTo(1)
+                .jsonPath("$.workflowRuns[0].id").isEqualTo(12345)
+                .jsonPath("$.workflowRuns[0].name").isEqualTo("Test Workflow")
+                .jsonPath("$.workflowRuns[0].status").isEqualTo("completed");
+    }
+
+    @Test
+    void testGetWorkflowRun() {
+        WorkflowRun run = new WorkflowRun();
+        run.setId(12345L);
+        run.setRunNumber(1);
+        run.setName("Test Workflow");
+        run.setStatus("completed");
+        run.setConclusion("success");
+        run.setHeadBranch("main");
+        run.setHeadSha("abc123");
+        run.setCreatedAt(LocalDateTime.now());
+        run.setHtmlUrl("https://github.com/test/repo/actions/runs/12345");
+        run.setEvent("push");
+        run.setActor("testuser");
+
+        when(gitHubActionsService.getWorkflowRun(anyString(), anyString(), anyLong()))
+                .thenReturn(Mono.just(run));
+
+        webTestClient.get()
+                .uri("/api/v1/github-actions/testowner/testrepo/runs/12345")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.id").isEqualTo(12345)
+                .jsonPath("$.name").isEqualTo("Test Workflow")
+                .jsonPath("$.status").isEqualTo("completed");
+    }
+
+    @Test
+    void testGetWorkflowRunsByBranch() {
+        WorkflowRunsResponse response = new WorkflowRunsResponse();
+        response.setTotalCount(1);
+
+        WorkflowRun run = new WorkflowRun();
+        run.setId(12345L);
+        run.setHeadBranch("feature-branch");
+
+        response.setWorkflowRuns(Arrays.asList(run));
+
+        when(gitHubActionsService.getWorkflowRunsByBranch(anyString(), anyString(), anyString(), anyInt()))
+                .thenReturn(Mono.just(response));
+
+        webTestClient.get()
+                .uri("/api/v1/github-actions/testowner/testrepo/runs/branch/feature-branch")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.totalCount").isEqualTo(1)
+                .jsonPath("$.workflowRuns[0].headBranch").isEqualTo("feature-branch");
+    }
+
+    @Test
+    void testGetWorkflowRunsByStatus() {
+        WorkflowRunsResponse response = new WorkflowRunsResponse();
+        response.setTotalCount(1);
+
+        WorkflowRun run = new WorkflowRun();
+        run.setId(12345L);
+        run.setStatus("in_progress");
+
+        response.setWorkflowRuns(Arrays.asList(run));
+
+        when(gitHubActionsService.getWorkflowRunsByStatus(anyString(), anyString(), anyString(), anyInt()))
+                .thenReturn(Mono.just(response));
+
+        webTestClient.get()
+                .uri("/api/v1/github-actions/testowner/testrepo/runs/status/in_progress")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.totalCount").isEqualTo(1)
+                .jsonPath("$.workflowRuns[0].status").isEqualTo("in_progress");
+    }
+}


### PR DESCRIPTION
Implemented a new REST API controller to fetch real-time GitHub Actions workflow run status.

Features:
- Get all workflow runs for a repository with pagination
- Get details of a specific workflow run by ID
- Filter workflow runs by branch name
- Filter workflow runs by status (completed, in_progress, queued)

Technical details:
- Added GitHubActionsController with RESTful endpoints
- Created GitHubActionsService using Spring WebFlux WebClient for GitHub API integration
- Added WorkflowRun and WorkflowRunsResponse models
- Configured GitHub API token support via environment variable
- Included comprehensive unit tests

API Endpoints:
- GET /api/v1/github-actions/{owner}/{repo}/runs
- GET /api/v1/github-actions/{owner}/{repo}/runs/{runId}
- GET /api/v1/github-actions/{owner}/{repo}/runs/branch/{branch}
- GET /api/v1/github-actions/{owner}/{repo}/runs/status/{status}

Closes #6