### PR TITLE
feat: 新增 GitHub Actions 状态查询 controller

### DIFF
--- a/GITHUB_ACTIONS_API.md
+++ b/GITHUB_ACTIONS_API.md
@@ -1,0 +1,198 @@
+# GitHub Actions 状态查询 API
+
+这个模块提供了实时获取 GitHub Actions 工作流运行状态的功能。
+
+## 功能特性
+
+- 获取指定仓库的工作流运行列表
+- 获取特定工作流运行的详细状态
+- 实时监控工作流运行状态（通过 Server-Sent Events）
+
+## API 接口
+
+### 1. 获取工作流运行列表
+
+**请求:**
+```
+GET /api/v1/github-actions/{owner}/{repo}/runs?perPage=30
+```
+
+**参数:**
+- `owner`: 仓库所有者
+- `repo`: 仓库名称
+- `perPage`: 每页数量（可选，默认 30，最大 100）
+
+**响应示例:**
+```json
+{
+  "totalCount": 100,
+  "workflowRuns": [
+    {
+      "id": 123456789,
+      "name": "CI",
+      "runNumber": 42,
+      "status": "completed",
+      "conclusion": "success",
+      "event": "push",
+      "headBranch": "main",
+      "headSha": "abc123def456",
+      "htmlUrl": "https://github.com/owner/repo/actions/runs/123456789",
+      "createdAt": "2024-01-01T10:00:00",
+      "updatedAt": "2024-01-01T10:05:00"
+    }
+  ]
+}
+```
+
+### 2. 获取工作流运行状态
+
+**请求:**
+```
+GET /api/v1/github-actions/{owner}/{repo}/runs/{runId}
+```
+
+**参数:**
+- `owner`: 仓库所有者
+- `repo`: 仓库名称
+- `runId`: 工作流运行 ID
+
+**响应示例:**
+```json
+{
+  "id": 123456789,
+  "name": "CI",
+  "runNumber": 42,
+  "status": "in_progress",
+  "conclusion": null,
+  "event": "push",
+  "headBranch": "feature-branch",
+  "headSha": "abc123def456",
+  "htmlUrl": "https://github.com/owner/repo/actions/runs/123456789",
+  "createdAt": "2024-01-01T10:00:00",
+  "updatedAt": "2024-01-01T10:05:00"
+}
+```
+
+### 3. 实时监控工作流运行状态（SSE）
+
+**请求:**
+```
+GET /api/v1/github-actions/{owner}/{repo}/runs/{runId}/watch?interval=5
+```
+
+**参数:**
+- `owner`: 仓库所有者
+- `repo`: 仓库名称
+- `runId`: 工作流运行 ID
+- `interval`: 轮询间隔（秒，可选，默认 5）
+
+**响应:**
+返回 Server-Sent Events 流，实时推送工作流状态更新，直到工作流完成。
+
+**使用示例（JavaScript）:**
+```javascript
+const eventSource = new EventSource(
+  '/api/v1/github-actions/owner/repo/runs/123456789/watch?interval=5'
+);
+
+eventSource.onmessage = (event) => {
+  const status = JSON.parse(event.data);
+  console.log('Workflow status:', status.status);
+  console.log('Conclusion:', status.conclusion);
+
+  if (status.status === 'completed') {
+    eventSource.close();
+  }
+};
+
+eventSource.onerror = (error) => {
+  console.error('Error:', error);
+  eventSource.close();
+};
+```
+
+## 状态说明
+
+### status 字段
+- `queued`: 排队中
+- `in_progress`: 执行中
+- `completed`: 已完成
+
+### conclusion 字段（仅在 status 为 completed 时有值）
+- `success`: 成功
+- `failure`: 失败
+- `cancelled`: 已取消
+- `skipped`: 已跳过
+- `timed_out`: 超时
+- `action_required`: 需要操作
+- `neutral`: 中性
+
+## 配置
+
+### GitHub API Token（可选）
+
+为了提高 API 速率限制，可以配置 GitHub Personal Access Token：
+
+**方式 1: 环境变量**
+```bash
+export GITHUB_TOKEN=your_github_token_here
+```
+
+**方式 2: application.yml**
+```yaml
+github:
+  api:
+    token: your_github_token_here
+```
+
+### 创建 GitHub Token
+
+1. 访问 GitHub Settings -> Developer settings -> Personal access tokens
+2. 生成新 token，选择以下权限：
+   - `repo` (如果需要访问私有仓库)
+   - `workflow` (读取工作流信息)
+3. 复制 token 并设置到环境变量或配置文件
+
+**注意:** 如果不设置 token，API 将使用未认证请求，速率限制为每小时 60 次。设置 token 后，速率限制提升至每小时 5000 次。
+
+## 测试
+
+运行测试：
+```bash
+mvn test -Dtest=GitHubActionsControllerTest
+```
+
+## 技术实现
+
+- 使用 Spring WebFlux 的 `WebClient` 调用 GitHub API
+- 支持响应式编程模型（Mono/Flux）
+- 实时监控通过 Server-Sent Events (SSE) 实现
+- 使用轮询机制定期获取状态更新
+- 状态去重，仅在状态变化时推送更新
+- 自动结束监控（当工作流状态为 completed 时）
+
+## 示例用法
+
+### 使用 curl 测试
+
+**获取工作流列表:**
+```bash
+curl http://localhost:8080/api/v1/github-actions/6522091/zbr_test/runs
+```
+
+**获取特定运行状态:**
+```bash
+curl http://localhost:8080/api/v1/github-actions/6522091/zbr_test/runs/123456789
+```
+
+**实时监控（SSE）:**
+```bash
+curl -N http://localhost:8080/api/v1/github-actions/6522091/zbr_test/runs/123456789/watch
+```
+
+## 依赖说明
+
+本功能使用现有依赖，无需额外添加：
+- Spring Boot WebFlux (已包含在 pom.xml)
+- Jackson (用于 JSON 处理，已包含)
+- Lombok (用于简化代码，已包含)

--- a/src/main/java/com/scheduler/controller/GitHubActionsController.java
+++ b/src/main/java/com/scheduler/controller/GitHubActionsController.java
@@ -1,0 +1,75 @@
+package com.scheduler.controller;
+
+import com.scheduler.model.WorkflowRunStatus;
+import com.scheduler.model.WorkflowRunsResponse;
+import com.scheduler.service.GitHubActionsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * GitHub Actions 状态查询控制器
+ * 提供实时获取 GitHub Actions 工作流运行状态的接口
+ */
+@RestController
+@RequestMapping("/api/v1/github-actions")
+@RequiredArgsConstructor
+public class GitHubActionsController {
+
+    private final GitHubActionsService gitHubActionsService;
+
+    /**
+     * 获取工作流运行列表
+     * GET /api/v1/github-actions/{owner}/{repo}/runs
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param perPage 每页数量（可选，默认 30）
+     * @return 工作流运行列表
+     */
+    @GetMapping("/{owner}/{repo}/runs")
+    public Mono<WorkflowRunsResponse> getWorkflowRuns(
+            @PathVariable String owner,
+            @PathVariable String repo,
+            @RequestParam(required = false, defaultValue = "30") Integer perPage) {
+        return gitHubActionsService.getWorkflowRuns(owner, repo, perPage);
+    }
+
+    /**
+     * 获取指定工作流运行的状态
+     * GET /api/v1/github-actions/{owner}/{repo}/runs/{runId}
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param runId 工作流运行 ID
+     * @return 工作流运行状态
+     */
+    @GetMapping("/{owner}/{repo}/runs/{runId}")
+    public Mono<WorkflowRunStatus> getWorkflowRunStatus(
+            @PathVariable String owner,
+            @PathVariable String repo,
+            @PathVariable Long runId) {
+        return gitHubActionsService.getWorkflowRunStatus(owner, repo, runId);
+    }
+
+    /**
+     * 实时监控工作流运行状态（Server-Sent Events）
+     * GET /api/v1/github-actions/{owner}/{repo}/runs/{runId}/watch
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param runId 工作流运行 ID
+     * @param interval 轮询间隔（秒，可选，默认 5）
+     * @return 工作流运行状态流（SSE）
+     */
+    @GetMapping(value = "/{owner}/{repo}/runs/{runId}/watch", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<WorkflowRunStatus> watchWorkflowRunStatus(
+            @PathVariable String owner,
+            @PathVariable String repo,
+            @PathVariable Long runId,
+            @RequestParam(required = false, defaultValue = "5") Long interval) {
+        return gitHubActionsService.watchWorkflowRunStatus(owner, repo, runId, interval);
+    }
+}

--- a/src/main/java/com/scheduler/model/WorkflowRunStatus.java
+++ b/src/main/java/com/scheduler/model/WorkflowRunStatus.java
@@ -1,0 +1,71 @@
+package com.scheduler.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * GitHub Actions 工作流运行状态
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkflowRunStatus {
+
+    /**
+     * 工作流运行 ID
+     */
+    private Long id;
+
+    /**
+     * 工作流名称
+     */
+    private String name;
+
+    /**
+     * 运行编号
+     */
+    private Integer runNumber;
+
+    /**
+     * 状态: queued, in_progress, completed
+     */
+    private String status;
+
+    /**
+     * 结论: success, failure, cancelled, skipped, timed_out, action_required, neutral
+     */
+    private String conclusion;
+
+    /**
+     * 创建时间
+     */
+    private LocalDateTime createdAt;
+
+    /**
+     * 更新时间
+     */
+    private LocalDateTime updatedAt;
+
+    /**
+     * 触发事件
+     */
+    private String event;
+
+    /**
+     * 分支
+     */
+    private String headBranch;
+
+    /**
+     * 提交 SHA
+     */
+    private String headSha;
+
+    /**
+     * HTML URL
+     */
+    private String htmlUrl;
+}

--- a/src/main/java/com/scheduler/model/WorkflowRunsResponse.java
+++ b/src/main/java/com/scheduler/model/WorkflowRunsResponse.java
@@ -1,0 +1,26 @@
+package com.scheduler.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * GitHub Actions 工作流运行列表响应
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkflowRunsResponse {
+
+    /**
+     * 总数
+     */
+    private Integer totalCount;
+
+    /**
+     * 工作流运行列表
+     */
+    private List<WorkflowRunStatus> workflowRuns;
+}

--- a/src/main/java/com/scheduler/service/GitHubActionsService.java
+++ b/src/main/java/com/scheduler/service/GitHubActionsService.java
@@ -1,0 +1,150 @@
+package com.scheduler.service;
+
+import com.scheduler.model.WorkflowRunStatus;
+import com.scheduler.model.WorkflowRunsResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * GitHub Actions API 服务
+ * 用于实时获取工作流运行状态
+ */
+@Slf4j
+@Service
+public class GitHubActionsService {
+
+    private final WebClient webClient;
+
+    @Value("${github.api.token:}")
+    private String githubToken;
+
+    public GitHubActionsService(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder
+                .baseUrl("https://api.github.com")
+                .defaultHeader("Accept", "application/vnd.github+json")
+                .defaultHeader("X-GitHub-Api-Version", "2022-11-28")
+                .build();
+    }
+
+    /**
+     * 获取指定仓库的工作流运行列表
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param perPage 每页数量，默认 30，最大 100
+     * @return 工作流运行列表
+     */
+    public Mono<WorkflowRunsResponse> getWorkflowRuns(String owner, String repo, Integer perPage) {
+        String uri = String.format("/repos/%s/%s/actions/runs?per_page=%d", owner, repo, perPage != null ? perPage : 30);
+
+        WebClient.RequestHeadersSpec<?> request = webClient.get()
+                .uri(uri);
+
+        if (githubToken != null && !githubToken.isEmpty()) {
+            request = request.header("Authorization", "Bearer " + githubToken);
+        }
+
+        return request.retrieve()
+                .bodyToMono(Map.class)
+                .map(this::convertToWorkflowRunsResponse)
+                .doOnError(error -> log.error("Error fetching workflow runs: {}", error.getMessage()));
+    }
+
+    /**
+     * 获取指定工作流运行的详细状态
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param runId 工作流运行 ID
+     * @return 工作流运行状态
+     */
+    public Mono<WorkflowRunStatus> getWorkflowRunStatus(String owner, String repo, Long runId) {
+        String uri = String.format("/repos/%s/%s/actions/runs/%d", owner, repo, runId);
+
+        WebClient.RequestHeadersSpec<?> request = webClient.get()
+                .uri(uri);
+
+        if (githubToken != null && !githubToken.isEmpty()) {
+            request = request.header("Authorization", "Bearer " + githubToken);
+        }
+
+        return request.retrieve()
+                .bodyToMono(Map.class)
+                .map(this::convertToWorkflowRunStatus)
+                .doOnError(error -> log.error("Error fetching workflow run status: {}", error.getMessage()));
+    }
+
+    /**
+     * 实时轮询获取工作流运行状态（Server-Sent Events 流）
+     *
+     * @param owner 仓库所有者
+     * @param repo 仓库名称
+     * @param runId 工作流运行 ID
+     * @param intervalSeconds 轮询间隔（秒）
+     * @return 工作流运行状态流
+     */
+    public Flux<WorkflowRunStatus> watchWorkflowRunStatus(String owner, String repo, Long runId, Long intervalSeconds) {
+        long interval = intervalSeconds != null ? intervalSeconds : 5;
+
+        return Flux.interval(java.time.Duration.ofSeconds(interval))
+                .flatMap(tick -> getWorkflowRunStatus(owner, repo, runId))
+                .distinctUntilChanged(WorkflowRunStatus::getStatus)
+                .takeUntil(status -> "completed".equalsIgnoreCase(status.getStatus()));
+    }
+
+    /**
+     * 转换 API 响应为 WorkflowRunsResponse
+     */
+    private WorkflowRunsResponse convertToWorkflowRunsResponse(Map<String, Object> response) {
+        WorkflowRunsResponse result = new WorkflowRunsResponse();
+        result.setTotalCount((Integer) response.get("total_count"));
+
+        List<Map<String, Object>> workflowRuns = (List<Map<String, Object>>) response.get("workflow_runs");
+        if (workflowRuns != null) {
+            List<WorkflowRunStatus> statusList = workflowRuns.stream()
+                    .map(this::convertToWorkflowRunStatus)
+                    .toList();
+            result.setWorkflowRuns(statusList);
+        }
+
+        return result;
+    }
+
+    /**
+     * 转换 API 响应为 WorkflowRunStatus
+     */
+    private WorkflowRunStatus convertToWorkflowRunStatus(Map<String, Object> run) {
+        WorkflowRunStatus status = new WorkflowRunStatus();
+
+        status.setId(((Number) run.get("id")).longValue());
+        status.setName((String) run.get("name"));
+        status.setRunNumber((Integer) run.get("run_number"));
+        status.setStatus((String) run.get("status"));
+        status.setConclusion((String) run.get("conclusion"));
+        status.setEvent((String) run.get("event"));
+        status.setHeadBranch((String) run.get("head_branch"));
+        status.setHeadSha((String) run.get("head_sha"));
+        status.setHtmlUrl((String) run.get("html_url"));
+
+        // 转换时间
+        String createdAt = (String) run.get("created_at");
+        if (createdAt != null) {
+            status.setCreatedAt(ZonedDateTime.parse(createdAt).toLocalDateTime());
+        }
+
+        String updatedAt = (String) run.get("updated_at");
+        if (updatedAt != null) {
+            status.setUpdatedAt(ZonedDateTime.parse(updatedAt).toLocalDateTime());
+        }
+
+        return status;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,10 @@ scheduler:
     connection-timeout: 10000
     # Runner执行超时时间（毫秒）
     execution-timeout: 30000
+
+# GitHub API配置
+github:
+  api:
+    # GitHub API Token (可选，用于提高速率限制)
+    # 未设置时使用未认证请求，速率限制较低
+    token: ${GITHUB_TOKEN:}

--- a/src/test/java/com/scheduler/controller/GitHubActionsControllerTest.java
+++ b/src/test/java/com/scheduler/controller/GitHubActionsControllerTest.java
@@ -1,0 +1,119 @@
+package com.scheduler.controller;
+
+import com.scheduler.model.WorkflowRunStatus;
+import com.scheduler.model.WorkflowRunsResponse;
+import com.scheduler.service.GitHubActionsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * GitHubActionsController 单元测试
+ */
+@WebFluxTest(GitHubActionsController.class)
+class GitHubActionsControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean
+    private GitHubActionsService gitHubActionsService;
+
+    private WorkflowRunStatus mockWorkflowRunStatus;
+    private WorkflowRunsResponse mockWorkflowRunsResponse;
+
+    @BeforeEach
+    void setUp() {
+        mockWorkflowRunStatus = new WorkflowRunStatus();
+        mockWorkflowRunStatus.setId(123456789L);
+        mockWorkflowRunStatus.setName("CI");
+        mockWorkflowRunStatus.setRunNumber(42);
+        mockWorkflowRunStatus.setStatus("completed");
+        mockWorkflowRunStatus.setConclusion("success");
+        mockWorkflowRunStatus.setEvent("push");
+        mockWorkflowRunStatus.setHeadBranch("main");
+        mockWorkflowRunStatus.setHeadSha("abc123");
+        mockWorkflowRunStatus.setHtmlUrl("https://github.com/owner/repo/actions/runs/123456789");
+        mockWorkflowRunStatus.setCreatedAt(LocalDateTime.now().minusMinutes(10));
+        mockWorkflowRunStatus.setUpdatedAt(LocalDateTime.now());
+
+        mockWorkflowRunsResponse = new WorkflowRunsResponse();
+        mockWorkflowRunsResponse.setTotalCount(1);
+        mockWorkflowRunsResponse.setWorkflowRuns(List.of(mockWorkflowRunStatus));
+    }
+
+    @Test
+    void testGetWorkflowRuns() {
+        when(gitHubActionsService.getWorkflowRuns(eq("owner"), eq("repo"), anyInt()))
+                .thenReturn(Mono.just(mockWorkflowRunsResponse));
+
+        webTestClient.get()
+                .uri("/api/v1/github-actions/owner/repo/runs?perPage=30")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(WorkflowRunsResponse.class)
+                .value(response -> {
+                    assert response.getTotalCount() == 1;
+                    assert response.getWorkflowRuns().size() == 1;
+                    assert response.getWorkflowRuns().get(0).getId().equals(123456789L);
+                });
+    }
+
+    @Test
+    void testGetWorkflowRunStatus() {
+        when(gitHubActionsService.getWorkflowRunStatus(eq("owner"), eq("repo"), eq(123456789L)))
+                .thenReturn(Mono.just(mockWorkflowRunStatus));
+
+        webTestClient.get()
+                .uri("/api/v1/github-actions/owner/repo/runs/123456789")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(WorkflowRunStatus.class)
+                .value(status -> {
+                    assert status.getId().equals(123456789L);
+                    assert status.getStatus().equals("completed");
+                    assert status.getConclusion().equals("success");
+                });
+    }
+
+    @Test
+    void testWatchWorkflowRunStatus() {
+        WorkflowRunStatus inProgressStatus = new WorkflowRunStatus();
+        inProgressStatus.setId(123456789L);
+        inProgressStatus.setStatus("in_progress");
+        inProgressStatus.setConclusion(null);
+
+        WorkflowRunStatus completedStatus = new WorkflowRunStatus();
+        completedStatus.setId(123456789L);
+        completedStatus.setStatus("completed");
+        completedStatus.setConclusion("success");
+
+        when(gitHubActionsService.watchWorkflowRunStatus(eq("owner"), eq("repo"), eq(123456789L), anyLong()))
+                .thenReturn(Flux.just(inProgressStatus, completedStatus));
+
+        webTestClient.get()
+                .uri("/api/v1/github-actions/owner/repo/runs/123456789/watch?interval=1")
+                .accept(MediaType.TEXT_EVENT_STREAM)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM)
+                .expectBodyList(WorkflowRunStatus.class)
+                .hasSize(2)
+                .value(statuses -> {
+                    assert statuses.get(0).getStatus().equals("in_progress");
+                    assert statuses.get(1).getStatus().equals("completed");
+                });
+    }
+}


### PR DESCRIPTION
实现了实时获取 GitHub Actions 工作流运行状态的功能：

- 新增 WorkflowRunStatus 和 WorkflowRunsResponse 模型
- 实现 GitHubActionsService 服务层，调用 GitHub API
- 创建 GitHubActionsController 提供 3 个 REST API 端点
- 支持获取工作流列表、单个运行状态查询和实时监控（SSE）
- 添加单元测试和详细的 API 文档

API 端点：
- GET /api/v1/github-actions/{owner}/{repo}/runs
- GET /api/v1/github-actions/{owner}/{repo}/runs/{runId}
- GET /api/v1/github-actions/{owner}/{repo}/runs/{runId}/watch